### PR TITLE
Improve interactive learning with badges and ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-App Web Ingegrales  GitHub Diseño Colorido 2025
-App Web Ingegrales  GitHub Diseño Colorido 2025
+# App Web Integrales 2025
+
+Pequeña aplicación educativa con ejercicios interactivos de integrales impropias.
+
+## Mejoras recientes
+
+- Interfaz modernizada y adaptable a móviles.
+- Sistema de puntajes, estadísticas y ranking local.
+- Desbloqueo de logros (badges) para motivar a los estudiantes.
+- Retroalimentación visual con animaciones y efectos.
+

--- a/index.html
+++ b/index.html
@@ -117,6 +117,7 @@
         <h2>🎉 ¡Ejercicio Completado!</h2>
         <div id="score" class="score">0%</div>
         <p id="performance-message" class="performance-message"></p>
+        <div id="ranking" class="ranking"></div>
         
         <div class="controls">
           <button id="restart-btn" class="btn">🔄 Reiniciar</button>
@@ -130,6 +131,13 @@
       <div class="theory-content">
         <button id="theory-close" class="theory-close">×</button>
         <div id="theory-body"></div>
+      </div>
+    </div>
+    <div id="badge-modal" class="badge-modal">
+      <div class="badge-content">
+        <h3>🏅 Nuevo logro</h3>
+        <p id="badge-name"></p>
+        <button id="badge-close" class="btn btn-secondary">Cerrar</button>
       </div>
     </div>
   </div>

--- a/styles.css
+++ b/styles.css
@@ -789,3 +789,52 @@ a.btn:hover, a.nav-btn:hover {
 a.btn:visited, a.nav-btn:visited {
     color: inherit;
 }
+
+/* Ranking */
+.ranking {
+  margin: 1rem 0;
+  padding: 1rem;
+  background: linear-gradient(135deg, #f3f4f6, #e5e7eb);
+  border-radius: 12px;
+  text-align: left;
+}
+
+.ranking ol {
+  padding-left: 1.2rem;
+}
+
+.ranking li {
+  margin: 0.25rem 0;
+  font-weight: 600;
+}
+
+/* Badge modal */
+.badge-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  opacity: 0;
+  visibility: hidden;
+  transition: all 0.3s ease;
+  z-index: 1100;
+}
+
+.badge-modal.show {
+  opacity: 1;
+  visibility: visible;
+}
+
+.badge-content {
+  background: white;
+  padding: 2rem;
+  border-radius: 12px;
+  text-align: center;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.3);
+}
+


### PR DESCRIPTION
## Summary
- refresh README
- display ranking and badge modal in results
- style ranking list and badge modal
- add gamification logic in JS for username, badges and ranking

## Testing
- `node --check main.js`
- `npm install -g htmlhint` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688d4e064a4c8331af810408551f287b