### PR TITLE
Handle missing exercises before starting

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,15 @@ Pequeña aplicación educativa con ejercicios interactivos de integrales impropi
 - Onboarding inicial para nuevos usuarios.
 - Base de ejercicios externalizada en `exercises.json`.
 
+## Pruebas manuales
+
+- **Tipo inexistente**
+  1. Abrir la consola del navegador.
+  2. Ejecutar `currentType = 'inexistente'; startExercise();`.
+  3. Verificar que se muestre el mensaje: "No hay ejercicios disponibles para este tipo.".
+
+- **Tipo sin ejercicios**
+  1. Abrir la consola del navegador.
+  2. Ejecutar `exercisesByType['vacio'] = []; currentType = 'vacio'; startExercise();`.
+  3. Verificar que se muestre el mensaje: "No hay ejercicios disponibles para este tipo.".
+

--- a/main.js
+++ b/main.js
@@ -406,20 +406,33 @@ document.addEventListener('DOMContentLoaded', function() {
   function startExercise() {
     wrongAnswers = [];
     const exercises = exercisesByType[currentType];
+
+    // Validar que existan ejercicios para el tipo actual
+    if (!exercises || exercises.length === 0) {
+      alert('No hay ejercicios disponibles para este tipo.');
+      return;
+    }
+
     const exercise = exercises[currentExercise];
-    
+
+    // Verificar que el ejercicio seleccionado exista
+    if (!exercise) {
+      alert('No se encontró el ejercicio seleccionado.');
+      return;
+    }
+
     // Ocultar selección, mostrar ejercicio
     typeSelection.style.display = 'none';
     exerciseSection.style.display = 'block';
     resultsSection.style.display = 'none';
-    
+
     // Configurar header del ejercicio
     exerciseTitle.innerHTML = exercise.name;
     exerciseDescription.textContent = exercise.description;
-    
+
     // Mostrar primer paso
     showStep();
-    
+
     // Renderizar MathJax en el título
     setTimeout(() => {
       if (window.MathJax && window.MathJax.typesetPromise) {


### PR DESCRIPTION
## Summary
- validate exercise availability before starting and alert users when type or exercise is missing
- document manual steps to test nonexistent or empty exercise types

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d8317890c8331ab5a817b64943732