### PR TITLE
Add fetch error handling for exercises

### DIFF
--- a/main.js
+++ b/main.js
@@ -1021,6 +1021,9 @@ document.addEventListener('DOMContentLoaded', function() {
   fetch("exercises.json").then(r => r.json()).then(data => {
     exercisesByType = data;
     initializeApp();
+  }).catch(error => {
+    alert("Error al cargar los ejercicios. Inténtalo de nuevo más tarde.");
+    console.error("Error al cargar exercises.json:", error);
   });
 
 }); // ← FIN DEL DOMContentLoaded


### PR DESCRIPTION
## Summary
- Add catch block to `fetch("exercises.json")` to notify user if exercises fail to load and log error to console.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d8311ea2c8331802d3621bbd6aa22