### PR TITLE
Manejar falla al cargar ejercicios

### DIFF
--- a/main.js
+++ b/main.js
@@ -1046,12 +1046,20 @@ document.addEventListener('DOMContentLoaded', function() {
   // ========== FIN DE MEJORAS ==========
 
   // ========== INICIALIZAR APLICACIÓN ==========
-  fetch("exercises.json").then(r => r.json()).then(data => {
-    exercisesByType = data;
-    initializeApp();
-  }).catch(error => {
-    alert("Error al cargar los ejercicios. Inténtalo de nuevo más tarde.");
-    console.error("Error al cargar exercises.json:", error);
-  });
+  fetch("exercises.json")
+    .then(r => r.json())
+    .then(data => {
+      exercisesByType = data;
+      initializeApp();
+    })
+    .catch(error => {
+      console.error("Error al cargar exercises.json:", error);
+      // Inicializar la aplicación aunque falle la carga
+      initializeApp();
+      const banner = document.createElement("div");
+      banner.className = "load-error";
+      banner.textContent = "No se pudieron cargar los ejercicios";
+      document.body.prepend(banner);
+    });
 
 }); // ← FIN DEL DOMContentLoaded

--- a/styles.css
+++ b/styles.css
@@ -22,6 +22,15 @@ body {
   padding: 10px;
 }
 
+.load-error {
+  background: #fee2e2;
+  color: #991b1b;
+  padding: 10px;
+  margin-bottom: 10px;
+  text-align: center;
+  border-radius: 4px;
+}
+
 .container {
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- Mostrar mensaje cuando `exercises.json` no se puede cargar y continuar con la inicialización
- Agregar estilo para el banner de error

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688de8401b308331a6cfad732c73d9c4